### PR TITLE
fix: Renames tutorials train_df to input_df

### DIFF
--- a/docs/tutorials/darkgrey_poc_demo_01.ipynb
+++ b/docs/tutorials/darkgrey_poc_demo_01.ipynb
@@ -69,10 +69,10 @@
     }
    ],
    "source": [
-    "train_df = pd.read_csv('./data/demo_data.csv', index_col=0, parse_dates=True)\n",
+    "input_df = pd.read_csv('./data/demo_data.csv', index_col=0, parse_dates=True)\n",
     "\n",
-    "input_X = train_df[['Ph', 'Ta']]\n",
-    "input_y = train_df['Ti']\n",
+    "input_X = input_df[['Ph', 'Ta']]\n",
+    "input_y = input_df['Ti']\n",
     "\n",
     "print(f'Input X shape: {input_X.shape}, input y shape: {input_y.shape}')"
    ]
@@ -96,7 +96,7 @@
     }
    ],
    "source": [
-    "plot_input_data(train_df)"
+    "plot_input_data(input_df)"
    ]
   },
   {

--- a/docs/tutorials/darkgrey_poc_demo_02.ipynb
+++ b/docs/tutorials/darkgrey_poc_demo_02.ipynb
@@ -77,10 +77,10 @@
     }
    ],
    "source": [
-    "train_df = pd.read_csv('./data/demo_data.csv', index_col=0, parse_dates=True)\n",
+    "input_df = pd.read_csv('./data/demo_data.csv', index_col=0, parse_dates=True)\n",
     "\n",
-    "input_X = train_df[['Ph', 'Ta', 'Th']]\n",
-    "input_y = train_df['Ti']\n",
+    "input_X = input_df[['Ph', 'Ta', 'Th']]\n",
+    "input_y = input_df['Ti']\n",
     "\n",
     "print(f'Input X shape: {input_X.shape}, input y shape: {input_y.shape}')"
    ]

--- a/docs/tutorials/darkgrey_poc_demo_03.ipynb
+++ b/docs/tutorials/darkgrey_poc_demo_03.ipynb
@@ -92,13 +92,13 @@
     }
    ],
    "source": [
-    "train_df = pd.read_csv('./data/demo_data.csv', index_col=0, parse_dates=True)\n",
+    "input_df = pd.read_csv('./data/demo_data.csv', index_col=0, parse_dates=True)\n",
     "\n",
-    "input_X = train_df[['Ph', 'Ta']]\n",
-    "input_y = train_df['Ti']\n",
+    "input_X = input_df[['Ph', 'Ta']]\n",
+    "input_y = input_df['Ti']\n",
     "\n",
     "input_X['Ti0'] = input_y\n",
-    "input_X['Te0'] = input_y - 2 \n",
+    "input_X['Te0'] = input_y - 2\n",
     "\n",
     "print(f'Input X shape: {input_X.shape}, input y shape: {input_y.shape}')"
    ]

--- a/docs/tutorials/darkgrey_poc_demo_04.ipynb
+++ b/docs/tutorials/darkgrey_poc_demo_04.ipynb
@@ -81,10 +81,10 @@
     }
    ],
    "source": [
-    "train_df = pd.read_csv('./data/demo_data.csv', index_col=0, parse_dates=True)\n",
+    "input_df = pd.read_csv('./data/demo_data.csv', index_col=0, parse_dates=True)\n",
     "\n",
-    "input_X = train_df[['Ph', 'Ta', 'Th']]\n",
-    "input_y = train_df['Ti']\n",
+    "input_X = input_df[['Ph', 'Ta', 'Th']]\n",
+    "input_y = input_df['Ti']\n",
     "\n",
     "input_X['Ti0'] = input_y\n",
     "input_X['Th0'] = input_y\n",


### PR DESCRIPTION
Fixes #18 

I did these whilst working on updating dependencies in my fork, as we need newer version of pandas and numpy. Would you accept PRs back for those too?